### PR TITLE
Fix for dictionary synchronization issue

### DIFF
--- a/src/main/java/org/apache/lucene/analysis/kr/utils/DictionaryUtil.java
+++ b/src/main/java/org/apache/lucene/analysis/kr/utils/DictionaryUtil.java
@@ -32,7 +32,7 @@ import org.apache.lucene.analysis.kr.morph.WordEntry;
 
 public class DictionaryUtil {
 	
-	private static Supplier<Trie<String,WordEntry>> DICTIONARY = Suppliers.memoize(new Supplier<Trie<String, WordEntry>>() {
+	private static Supplier<Trie<String, WordEntry>> DICTIONARY = Suppliers.memoize(new Supplier<Trie<String, WordEntry>>() {
         @Override
         public Trie<String, WordEntry> get() {
             try {
@@ -46,44 +46,28 @@ public class DictionaryUtil {
 	private static Supplier<Map<String, String>> JOSAS = Suppliers.memoize(new Supplier<Map<String, String>>() {
         @Override
         public Map<String, String> get() {
-            try {
-                return readDict(KoreanEnv.FILE_JOSA);
-            } catch (MorphException e) {
-                throw new RuntimeException("Failed to initialize JOSA dictionary.", e);
-            }
+            return readDict(KoreanEnv.FILE_JOSA);
         }
     });
 	
 	private static Supplier<Map<String, String>> EOMIS = Suppliers.memoize(new Supplier<Map<String, String>>() {
         @Override
         public Map<String, String> get() {
-            try {
-                return readDict(KoreanEnv.FILE_EOMI);
-            } catch (MorphException e) {
-                throw new RuntimeException("Failed to initialize EOMI dictionary.", e);
-            }
+            return readDict(KoreanEnv.FILE_EOMI);
         }
     });
 
     private static Supplier<Map<String, String>> PREFIXS = Suppliers.memoize(new Supplier<Map<String, String>>() {
         @Override
         public Map<String, String> get() {
-            try {
-                return readDict(KoreanEnv.FILE_PREFIX);
-            } catch (MorphException e) {
-                throw new RuntimeException("Failed to initialize PREFIX dictionary.", e);
-            }
+            return readDict(KoreanEnv.FILE_PREFIX);
         }
     });
 
     private static Supplier<Map<String, String>> SUFFIXS = Suppliers.memoize(new Supplier<Map<String, String>>() {
         @Override
         public Map<String, String> get() {
-            try {
-                return readDict(KoreanEnv.FILE_SUFFIX);
-            } catch (MorphException e) {
-                throw new RuntimeException("Failed to initialize SUFFIX dictionary.", e);
-            }
+            return readDict(KoreanEnv.FILE_SUFFIX);
         }
     });
 
@@ -118,7 +102,7 @@ public class DictionaryUtil {
             List<String> lines;
 
             try {
-                lines = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_CJ),"UTF-8");
+                lines = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_CJ), "UTF-8");
             } catch (Exception e) {
                 throw new RuntimeException("Failed to initialize CJWORDS dictionary.", e);
             }
@@ -312,12 +296,12 @@ public class DictionaryUtil {
 	 * @param type	1: josa, 2: eomi
 	 * @throws MorphException
 	 */
-	private static Map<String, String> readDict(String dic) throws MorphException {
+	private static Map<String, String> readDict(String dic) {
 		
-		String path = KoreanEnv.getInstance().getValue(dic);
-        HashMap<String, String> map = new HashMap<String, String>();
+		try {
+            String path = KoreanEnv.getInstance().getValue(dic);
+            HashMap<String, String> map = new HashMap<String, String>();
 
-        try {
 			List<String> line = FileUtil.readLines(path,"UTF-8");
 			for(int i=1;i<line.size();i++) {
 				map.put(line.get(i).trim(), line.get(i));
@@ -326,7 +310,7 @@ public class DictionaryUtil {
             return Collections.unmodifiableMap(map);
 
 		} catch (Exception e) {
- 		    throw new MorphException(e.getMessage(),e);
+ 		    throw new RuntimeException(String.format("Failed to initialize %s dictionary ", dic), e);
 		}
 	}
 	

--- a/src/main/java/org/apache/lucene/analysis/kr/utils/DictionaryUtil.java
+++ b/src/main/java/org/apache/lucene/analysis/kr/utils/DictionaryUtil.java
@@ -290,12 +290,6 @@ public class DictionaryUtil {
 		
 	}
 	
-	/**
-	 * 
-	 * @param map
-	 * @param type	1: josa, 2: eomi
-	 * @throws MorphException
-	 */
 	private static Map<String, String> readDict(String dic) {
 		
 		try {

--- a/src/main/java/org/apache/lucene/analysis/kr/utils/DictionaryUtil.java
+++ b/src/main/java/org/apache/lucene/analysis/kr/utils/DictionaryUtil.java
@@ -18,36 +18,127 @@ package org.apache.lucene.analysis.kr.utils;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import org.apache.lucene.analysis.kr.morph.CompoundEntry;
 import org.apache.lucene.analysis.kr.morph.MorphException;
 import org.apache.lucene.analysis.kr.morph.WordEntry;
 
 public class DictionaryUtil {
 	
-	private static Trie<String,WordEntry> dictionary;
+	private static Supplier<Trie<String,WordEntry>> DICTIONARY = Suppliers.memoize(new Supplier<Trie<String, WordEntry>>() {
+        @Override
+        public Trie<String, WordEntry> get() {
+            try {
+                return loadDictionary();
+            } catch (MorphException e) {
+                throw new RuntimeException("Failed to initialize DICTIONARY.", e);
+            }
+        }
+    });
 	
-	private static HashMap josas;
+	private static Supplier<Map<String, String>> JOSAS = Suppliers.memoize(new Supplier<Map<String, String>>() {
+        @Override
+        public Map<String, String> get() {
+            try {
+                return readDict(KoreanEnv.FILE_JOSA);
+            } catch (MorphException e) {
+                throw new RuntimeException("Failed to initialize JOSA dictionary.", e);
+            }
+        }
+    });
 	
-	private static HashMap eomis;
+	private static Supplier<Map<String, String>> EOMIS = Suppliers.memoize(new Supplier<Map<String, String>>() {
+        @Override
+        public Map<String, String> get() {
+            try {
+                return readDict(KoreanEnv.FILE_EOMI);
+            } catch (MorphException e) {
+                throw new RuntimeException("Failed to initialize EOMI dictionary.", e);
+            }
+        }
+    });
+
+    private static Supplier<Map<String, String>> PREFIXS = Suppliers.memoize(new Supplier<Map<String, String>>() {
+        @Override
+        public Map<String, String> get() {
+            try {
+                return readDict(KoreanEnv.FILE_PREFIX);
+            } catch (MorphException e) {
+                throw new RuntimeException("Failed to initialize PREFIX dictionary.", e);
+            }
+        }
+    });
+
+    private static Supplier<Map<String, String>> SUFFIXS = Suppliers.memoize(new Supplier<Map<String, String>>() {
+        @Override
+        public Map<String, String> get() {
+            try {
+                return readDict(KoreanEnv.FILE_SUFFIX);
+            } catch (MorphException e) {
+                throw new RuntimeException("Failed to initialize SUFFIX dictionary.", e);
+            }
+        }
+    });
+
+	private static Supplier<Map<String, WordEntry>> UNCOMPOUNDS = Suppliers.memoize(new Supplier<Map<String, WordEntry>>() {
+        @Override
+        public Map<String, WordEntry> get() {
+            Map<String, WordEntry> uncompounds = new HashMap<String, WordEntry>();
+            List<String> lines;
+
+            try {
+                lines = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_UNCOMPOUNDS),"UTF-8");
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to initialize UNCOMPOUNDS dictionary.", e);
+            }
+
+            for(String compound: lines) {
+                String[] infos = StringUtil.split(compound,":");
+                if(infos.length!=2) continue;
+                WordEntry entry = new WordEntry(infos[0].trim(),"90000X".toCharArray());
+                entry.setCompounds(compoundArrayToList(infos[1], StringUtil.split(infos[1],",")));
+                uncompounds.put(entry.getWord(), entry);
+            }
+
+            return Collections.unmodifiableMap(uncompounds);
+        }
+    });
 	
-	private static HashMap prefixs;
-	
-	private static HashMap suffixs;
-	
-	private static HashMap<String,WordEntry> uncompounds;
-	
-	private static HashMap<String, String> cjwords;
+	private static Supplier<Map<String, String>> CJWORDS = Suppliers.memoize(new Supplier<Map<String, String>>() {
+        @Override
+        public Map<String, String> get() {
+            Map<String, String> cjwords = new HashMap<String, String>();
+            List<String> lines;
+
+            try {
+                lines = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_CJ),"UTF-8");
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to initialize CJWORDS dictionary.", e);
+            }
+
+            for(String cj: lines) {
+                String[] infos = StringUtil.split(cj,":");
+                if(infos.length!=2) continue;
+                cjwords.put(infos[0], infos[1]);
+            }
+
+            return Collections.unmodifiableMap(cjwords);
+        }
+    });
 	
 	/**
 	 * 사전을 로드한다.
 	 */
-	public synchronized static void loadDictionary() throws MorphException {
-		
-		dictionary = new Trie<String, WordEntry>(true);
+	public synchronized static Trie<String, WordEntry> loadDictionary() throws MorphException {
+
+        Trie<String, WordEntry> dictionary = new Trie<String, WordEntry>(true);
 		List<String> strList = null;
 		List<String> compounds = null;
 		try {
@@ -78,18 +169,16 @@ public class DictionaryUtil {
 			entry.setCompounds(compoundArrayToList(infos[1], StringUtil.split(infos[1],",")));
 			dictionary.add(entry.getWord(), entry);
 		}
+
+        return dictionary;
 	}
 	
 	public static Iterator findWithPrefix(String prefix) throws MorphException {
-		if(dictionary==null) loadDictionary();
-		return dictionary.getPrefixedBy(prefix);
+		return DICTIONARY.get().getPrefixedBy(prefix);
 	}
 
 	public static WordEntry getWord(String key) throws MorphException {		
-		if(dictionary==null) loadDictionary();
-		if(key.length()==0) return null;
-		
-		return (WordEntry)dictionary.get(key);
+		return (WordEntry) DICTIONARY.get().get(key);
 	}
 	
 	public static WordEntry getWordExceptVerb(String key) throws MorphException {		
@@ -172,82 +261,27 @@ public class DictionaryUtil {
 	}
 	
 	public static WordEntry getUncompound(String key) throws MorphException {
-		
-		try {
-			if(uncompounds==null) {
-				uncompounds = new HashMap();
-				List<String> lines = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_UNCOMPOUNDS),"UTF-8");	
-				for(String compound: lines) {		
-					String[] infos = StringUtil.split(compound,":");
-					if(infos.length!=2) continue;
-					WordEntry entry = new WordEntry(infos[0].trim(),"90000X".toCharArray());
-					entry.setCompounds(compoundArrayToList(infos[1], StringUtil.split(infos[1],",")));
-					uncompounds.put(entry.getWord(), entry);
-				}			
-			}	
-		}catch(Exception e) {
-			throw new MorphException(e);
-		}
-		return uncompounds.get(key);
+		return UNCOMPOUNDS.get().get(key);
 	}
 	
 	public static String getCJWord(String key) throws MorphException {
-		
-		try {
-			if(cjwords==null) {
-				cjwords = new HashMap();
-				List<String> lines = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_CJ),"UTF-8");	
-				for(String cj: lines) {		
-					String[] infos = StringUtil.split(cj,":");
-					if(infos.length!=2) continue;
-					cjwords.put(infos[0], infos[1]);
-				}			
-			}	
-		}catch(Exception e) {
-			throw new MorphException(e);
-		}
-		return cjwords.get(key);
-		
+		return CJWORDS.get().get(key);
 	}
 	
 	public static boolean existJosa(String str) throws MorphException {
-		if(josas==null) {
-			josas = new HashMap();
-			readFile(josas,KoreanEnv.FILE_JOSA);
-		}	
-		if(josas.get(str)==null) return false;
-		else return true;
+		return JOSAS.get().get(str) != null;
 	}
 	
 	public static boolean existEomi(String str)  throws MorphException {
-		if(eomis==null) {
-			eomis = new HashMap();
-			readFile(eomis,KoreanEnv.FILE_EOMI);
-		}
-
-		if(eomis.get(str)==null) return false;
-		else return true;
+        return EOMIS.get().get(str) != null;
 	}
 	
 	public static boolean existPrefix(String str)  throws MorphException {
-		if(prefixs==null) {
-			prefixs = new HashMap();
-			readFile(prefixs,KoreanEnv.FILE_PREFIX);
-		}
-
-		if(prefixs.get(str)==null) return false;
-		else return true;
+        return PREFIXS.get().get(str) != null;
 	}
 	
 	public static boolean existSuffix(String str)  throws MorphException {
-		if(suffixs==null) {
-			suffixs = new HashMap();
-			readFile(suffixs,KoreanEnv.FILE_SUFFIX);
-		}
-
-		if(suffixs.get(str)!=null) return true;
-		
-		return false;
+        return SUFFIXS.get().get(str) != null;
 	}
 	
 	/**
@@ -278,17 +312,19 @@ public class DictionaryUtil {
 	 * @param type	1: josa, 2: eomi
 	 * @throws MorphException
 	 */
-	private static synchronized void readFile(HashMap map, String dic) throws MorphException {		
+	private static Map<String, String> readDict(String dic) throws MorphException {
 		
 		String path = KoreanEnv.getInstance().getValue(dic);
+        HashMap<String, String> map = new HashMap<String, String>();
 
-		try{
+        try {
 			List<String> line = FileUtil.readLines(path,"UTF-8");
 			for(int i=1;i<line.size();i++) {
 				map.put(line.get(i).trim(), line.get(i));
 			}
-		}catch(IOException e) {
- 		    throw new MorphException(e.getMessage(),e);
+
+            return Collections.unmodifiableMap(map);
+
 		} catch (Exception e) {
  		    throw new MorphException(e.getMessage(),e);
 		}


### PR DESCRIPTION
There is one (or two) issue when dictionaries are lazily initialized. The null verification that checks whether a dictionary has been initialized or not is not synchronized. That means that a dictionary may be loaded more than once, because the reference to it is not synced.

The other big issue is that on at least two of those dictionaries, the reference to the new dictionary escapes before it has completely been built. That leads to several problems when a second instance of the same dictionary is initialized while another thread is reading the first instance of that same dictionary.

The fix uses Guava's memoize to make sure that a dict is initialized only once and safely published. I was able to reproduce the bug and verify the fix with the code below.

```      
        ExecutorService executorService = Executors.newFixedThreadPool(20);
        List<String> lines = FileUtils.readLines(new File("korean_strings_random.txt"), "UTF-8");

        for (final String line : lines) {
            executorService.submit(new Runnable() {
                @Override
                public void run() {
                    try {
                        KoreanTokenizer koreanTokenizer = new KoreanTokenizer();
                        KoreanFilter koreanFilter = new KoreanFilter(koreanTokenizer);
                        koreanTokenizer.setReader(new StringReader(line));
                        koreanFilter.reset();

                        while (koreanFilter.incrementToken()) ;
                    } catch (Throwable e) {
                        e.printStackTrace();
                    }
                }
            });
        }
```

Note that I did a very minimal effort to make those dictionary immutable, which would be ideal to avoid any future sync issue. I considered it out of the scope of this fix, since it wasn't required to fix the current dict initialization issues.